### PR TITLE
add bn.js package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "bignumber.js": "9.1.2",
         "node-cache": "5.1.2",
         "tsup": "8.3.5",
-        "vitest": "2.1.9"
+        "vitest": "2.1.9",
+        "bn.js": "^5.2.1"
     },
     "devDependencies": {
         "@biomejs/biome": "1.5.3",


### PR DESCRIPTION
bn.js is needed. 
When we need devlelop based on the plugin-sui , we need build. At that time, bn.js  is needed. 